### PR TITLE
feat: lambda runtime select option

### DIFF
--- a/cdk/arch/edge-bundled.ts
+++ b/cdk/arch/edge-bundled.ts
@@ -15,6 +15,7 @@ import {
   appPath,
   certificateArn,
   domainName,
+  lambdaRuntime,
   memorySize
 } from '../external/params'
 
@@ -25,7 +26,12 @@ export class CDKStack extends Stack {
     const edge = new aws_cloudfront.experimental.EdgeFunction(this, 'Edge', {
       code: aws_lambda.Code.fromAsset('edge'),
       handler: 'server.handler',
-      runtime: aws_lambda.Runtime.NODEJS_18_X,
+      runtime:
+        lambdaRuntime === 'NODE_18'
+          ? aws_lambda.Runtime.NODEJS_18_X
+          : lambdaRuntime === 'NODE_20'
+          ? aws_lambda.Runtime.NODEJS_20_X
+          : aws_lambda.Runtime.NODEJS_LATEST,
       timeout: Duration.seconds(30),
       memorySize
     })

--- a/cdk/arch/edge-bundled.ts
+++ b/cdk/arch/edge-bundled.ts
@@ -30,8 +30,8 @@ export class CDKStack extends Stack {
         lambdaRuntime === 'NODE_18'
           ? aws_lambda.Runtime.NODEJS_18_X
           : lambdaRuntime === 'NODE_20'
-          ? aws_lambda.Runtime.NODEJS_20_X
-          : aws_lambda.Runtime.NODEJS_LATEST,
+            ? aws_lambda.Runtime.NODEJS_20_X
+            : aws_lambda.Runtime.NODEJS_LATEST,
       timeout: Duration.seconds(30),
       memorySize
     })

--- a/cdk/arch/edge-unbundled.ts
+++ b/cdk/arch/edge-unbundled.ts
@@ -18,6 +18,7 @@ import {
   certificateArn,
   domainName,
   environment,
+  lambdaRuntime,
   memorySize,
   stream
 } from '../external/params'
@@ -29,7 +30,12 @@ export class CDKStack extends Stack {
     const timeout = Duration.seconds(30)
 
     const lambdaURL = new aws_lambda.Function(this, 'Server', {
-      runtime: aws_lambda.Runtime.NODEJS_18_X,
+      runtime:
+        lambdaRuntime === 'NODE_18'
+          ? aws_lambda.Runtime.NODEJS_18_X
+          : lambdaRuntime === 'NODE_20'
+          ? aws_lambda.Runtime.NODEJS_20_X
+          : aws_lambda.Runtime.NODEJS_LATEST,
       code: aws_lambda.Code.fromAsset('lambda'),
       handler: 'server.handler',
       architecture: aws_lambda.Architecture.ARM_64,
@@ -46,7 +52,12 @@ export class CDKStack extends Stack {
     const edge = new aws_cloudfront.experimental.EdgeFunction(this, 'Edge', {
       code: aws_lambda.Code.fromAsset('edge'),
       handler: 'server.handler',
-      runtime: aws_lambda.Runtime.NODEJS_18_X,
+      runtime:
+        lambdaRuntime === 'NODE_18'
+          ? aws_lambda.Runtime.NODEJS_18_X
+          : lambdaRuntime === 'NODE_20'
+          ? aws_lambda.Runtime.NODEJS_20_X
+          : aws_lambda.Runtime.NODEJS_LATEST,
       timeout
     })
 

--- a/cdk/arch/edge-unbundled.ts
+++ b/cdk/arch/edge-unbundled.ts
@@ -34,8 +34,8 @@ export class CDKStack extends Stack {
         lambdaRuntime === 'NODE_18'
           ? aws_lambda.Runtime.NODEJS_18_X
           : lambdaRuntime === 'NODE_20'
-          ? aws_lambda.Runtime.NODEJS_20_X
-          : aws_lambda.Runtime.NODEJS_LATEST,
+            ? aws_lambda.Runtime.NODEJS_20_X
+            : aws_lambda.Runtime.NODEJS_LATEST,
       code: aws_lambda.Code.fromAsset('lambda'),
       handler: 'server.handler',
       architecture: aws_lambda.Architecture.ARM_64,
@@ -56,8 +56,8 @@ export class CDKStack extends Stack {
         lambdaRuntime === 'NODE_18'
           ? aws_lambda.Runtime.NODEJS_18_X
           : lambdaRuntime === 'NODE_20'
-          ? aws_lambda.Runtime.NODEJS_20_X
-          : aws_lambda.Runtime.NODEJS_LATEST,
+            ? aws_lambda.Runtime.NODEJS_20_X
+            : aws_lambda.Runtime.NODEJS_LATEST,
       timeout
     })
 

--- a/cdk/arch/lambda-mono.ts
+++ b/cdk/arch/lambda-mono.ts
@@ -31,8 +31,8 @@ export class CDKStack extends Stack {
         lambdaRuntime === 'NODE_18'
           ? aws_lambda.Runtime.NODEJS_18_X
           : lambdaRuntime === 'NODE_20'
-          ? aws_lambda.Runtime.NODEJS_20_X
-          : aws_lambda.Runtime.NODEJS_LATEST,
+            ? aws_lambda.Runtime.NODEJS_20_X
+            : aws_lambda.Runtime.NODEJS_LATEST,
       code: aws_lambda.Code.fromAsset('lambda'),
       handler: 'server.handler',
       architecture: aws_lambda.Architecture.ARM_64,

--- a/cdk/arch/lambda-mono.ts
+++ b/cdk/arch/lambda-mono.ts
@@ -17,6 +17,7 @@ import {
   certificateArn,
   domainName,
   environment,
+  lambdaRuntime,
   memorySize,
   stream
 } from '../external/params'
@@ -26,7 +27,12 @@ export class CDKStack extends Stack {
     super(scope, id, props)
 
     const lambdaURL = new aws_lambda.Function(this, 'Server', {
-      runtime: aws_lambda.Runtime.NODEJS_18_X,
+      runtime:
+        lambdaRuntime === 'NODE_18'
+          ? aws_lambda.Runtime.NODEJS_18_X
+          : lambdaRuntime === 'NODE_20'
+          ? aws_lambda.Runtime.NODEJS_20_X
+          : aws_lambda.Runtime.NODEJS_LATEST,
       code: aws_lambda.Code.fromAsset('lambda'),
       handler: 'server.handler',
       architecture: aws_lambda.Architecture.ARM_64,

--- a/cdk/arch/lambda-s3.ts
+++ b/cdk/arch/lambda-s3.ts
@@ -18,6 +18,7 @@ import {
   certificateArn,
   domainName,
   environment,
+  lambdaRuntime,
   memorySize,
   stream
 } from '../external/params'
@@ -27,7 +28,12 @@ export class CDKStack extends Stack {
     super(scope, id, props)
 
     const lambdaURL = new aws_lambda.Function(this, 'Server', {
-      runtime: aws_lambda.Runtime.NODEJS_18_X,
+      runtime:
+        lambdaRuntime === 'NODE_18'
+          ? aws_lambda.Runtime.NODEJS_18_X
+          : lambdaRuntime === 'NODE_20'
+          ? aws_lambda.Runtime.NODEJS_20_X
+          : aws_lambda.Runtime.NODEJS_LATEST,
       code: aws_lambda.Code.fromAsset('lambda'),
       handler: 'server.handler',
       architecture: aws_lambda.Architecture.ARM_64,

--- a/cdk/arch/lambda-s3.ts
+++ b/cdk/arch/lambda-s3.ts
@@ -32,8 +32,8 @@ export class CDKStack extends Stack {
         lambdaRuntime === 'NODE_18'
           ? aws_lambda.Runtime.NODEJS_18_X
           : lambdaRuntime === 'NODE_20'
-          ? aws_lambda.Runtime.NODEJS_20_X
-          : aws_lambda.Runtime.NODEJS_LATEST,
+            ? aws_lambda.Runtime.NODEJS_20_X
+            : aws_lambda.Runtime.NODEJS_LATEST,
       code: aws_lambda.Code.fromAsset('lambda'),
       handler: 'server.handler',
       architecture: aws_lambda.Architecture.ARM_64,

--- a/cdk/external/params.ts
+++ b/cdk/external/params.ts
@@ -8,6 +8,8 @@ export const environment = {} /* $$__ENVIRONMENT__$$ */
 export const cdn = false /* $$__ENABLE_CDN__$$ */
 export const stream = true /* $$__ENABLE_STREAM__$$ */
 export const bridgeAuthToken = '__BRIDGE_AUTH_TOKEN__'
+export const lambdaRuntime: 'NODE_LATEST' | 'NODE_20' | 'NODE_18' =
+  '__LAMBDA_RUNTIME__' as 'NODE_LATEST'
 export const staticAssetsPaths: Set<string> = new Set(
   [] /* $$__STATIC_ASSETS_PATHS__$$ */
 )

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jill64/sveltekit-adapter-aws",
   "description": "🔌 SveleteKit AWS adapter with multiple architecture",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "type": "module",
   "main": "dist/index.js",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jill64/sveltekit-adapter-aws.git",
-    "image": "https://opengraph.githubassets.com/50d7d96fdf41e9c47933095e2ccefa27de6ec33fad39599e30f009bfdabea5ed/jill64/sveltekit-adapter-aws"
+    "image": "https://opengraph.githubassets.com/ef08bba5a763ced100ea1368c911f992b9122f3d3d2948998834eda43969f69d/jill64/sveltekit-adapter-aws"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/adapter/src/steps/setup.ts
+++ b/packages/adapter/src/steps/setup.ts
@@ -70,6 +70,7 @@ export const setup = async ({ builder, tmp, options }: Context) => {
       __BRIDGE_AUTH_TOKEN__: bridgeAuthToken,
       __DOMAIN_NAME__: options.domain?.fqdn ?? '',
       __CERTIFICATE_ARN__: options.domain?.certificateArn ?? '',
+      __LAMBDA_RUNTIME__: options.runtime ?? 'NODE_LATEST',
       '{} /* $$__ENVIRONMENT__$$ */': JSON.stringify(options.env ?? {})
     }
   )

--- a/packages/adapter/src/types/AdapterOptions.ts
+++ b/packages/adapter/src/types/AdapterOptions.ts
@@ -65,7 +65,6 @@ export type AdapterOptions = {
    */
   stream?: boolean
 
-
   /**
    * Lambda runtime environment
    * @default 'NODE_LATEST'

--- a/packages/adapter/src/types/AdapterOptions.ts
+++ b/packages/adapter/src/types/AdapterOptions.ts
@@ -65,6 +65,13 @@ export type AdapterOptions = {
    */
   stream?: boolean
 
+
+  /**
+   * Lambda runtime environment
+   * @default 'NODE_LATEST'
+   */
+  runtime?: 'NODE_LATEST' | 'NODE_20' | 'NODE_18'
+
   /**
    * Custom domain of CloudFront distribution
    * @default undefined


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic Lambda runtime selection, allowing users to choose between Node.js 18, Node.js 20, or the latest Node.js version for enhanced flexibility in deployments.
- **Documentation**
  - Updated the repository image URL in `package.json` for better representation in documentation and metadata.
- **Refactor**
  - Added a new `runtime` parameter to various configurations, ensuring that Lambda functions can dynamically adjust based on the specified runtime environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->