### PR TITLE
chore: update pnpm/action-setup to v4 in deploy-test workflows

### DIFF
--- a/.github/workflows/deploy-test-buffered.yml
+++ b/.github/workflows/deploy-test-buffered.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: latest
           run_install: true

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: 20
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
           version: latest
           run_install: true

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jill64/sveltekit-adapter-aws.git",
-    "image": "https://opengraph.githubassets.com/76eb2a8b0346a6fc740ddbbdf7984cd6779b5819a82bee16be46546f519635f0/jill64/sveltekit-adapter-aws"
+    "image": "https://opengraph.githubassets.com/f49efacdf1ca3258ffa64a7d1626ccdbd551d21d52d12542fe41b9e0f65fcbd2/jill64/sveltekit-adapter-aws"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated GitHub Action `pnpm/action-setup` version from `v2` to `v4` for better compatibility and performance.

- **Documentation**
  - Updated the `repository` field image URL in `package.json` for improved clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->