### PR TITLE
Modify adapter to allow modifying CDK lambda

### DIFF
--- a/cdk/arch/lambda-s3.ts
+++ b/cdk/arch/lambda-s3.ts
@@ -20,14 +20,15 @@ import {
   environment,
   lambdaRuntime,
   memorySize,
-  stream
+  stream,
+  lambdaModifier,
 } from '../external/params'
 
 export class CDKStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props)
 
-    const lambdaURL = new aws_lambda.Function(this, 'Server', {
+    const lambdaFunction = new aws_lambda.Function(this, 'Server', {
       runtime:
         lambdaRuntime === 'NODE_18'
           ? aws_lambda.Runtime.NODEJS_18_X
@@ -40,7 +41,12 @@ export class CDKStack extends Stack {
       memorySize,
       timeout: Duration.seconds(30),
       environment
-    }).addFunctionUrl({
+    });
+    
+    // allow custom modification of CDK lambda function
+    lambdaModifier(lambdaFunction);
+
+    const lambdaURL = lambdaFunction.addFunctionUrl({
       authType: aws_lambda.FunctionUrlAuthType.NONE,
       invokeMode: stream
         ? aws_lambda.InvokeMode.RESPONSE_STREAM

--- a/cdk/arch/lambda-s3.ts
+++ b/cdk/arch/lambda-s3.ts
@@ -21,8 +21,10 @@ import {
   lambdaRuntime,
   memorySize,
   stream,
-  lambdaModifier,
 } from '../external/params'
+import {
+  lambdaModifier
+} from '../external/cdk-modifiers'
 
 export class CDKStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {

--- a/cdk/external/cdk-modifiers.ts
+++ b/cdk/external/cdk-modifiers.ts
@@ -1,0 +1,4 @@
+/* $$__ADAPTER_IMPORTS__$$ */
+import * as cdk from 'aws-cdk-lib'
+
+export const lambdaModifier = (lambdaFunction: cdk.aws_lambda.Function) => {} /* $$__LAMBDA_MODIFIER__$$ */

--- a/cdk/external/params.ts
+++ b/cdk/external/params.ts
@@ -1,3 +1,5 @@
+import type * as cdk from 'aws-cdk-lib'
+
 export const appDir = '__APP_DIR__'
 export const base = '__BASE_PATH__'
 export const domainName = '__DOMAIN_NAME__'
@@ -13,3 +15,4 @@ export const lambdaRuntime: 'NODE_LATEST' | 'NODE_20' | 'NODE_18' =
 export const staticAssetsPaths: Set<string> = new Set(
   [] /* $$__STATIC_ASSETS_PATHS__$$ */
 )
+export const lambdaModifier = (lambdaFunction: cdk.aws_lambda.Function) => {} /* $$__LAMBDA_MODIFIER__$$ */

--- a/cdk/external/params.ts
+++ b/cdk/external/params.ts
@@ -1,5 +1,3 @@
-import type * as cdk from 'aws-cdk-lib'
-
 export const appDir = '__APP_DIR__'
 export const base = '__BASE_PATH__'
 export const domainName = '__DOMAIN_NAME__'
@@ -15,4 +13,3 @@ export const lambdaRuntime: 'NODE_LATEST' | 'NODE_20' | 'NODE_18' =
 export const staticAssetsPaths: Set<string> = new Set(
   [] /* $$__STATIC_ASSETS_PATHS__$$ */
 )
-export const lambdaModifier = (lambdaFunction: cdk.aws_lambda.Function) => {} /* $$__LAMBDA_MODIFIER__$$ */

--- a/packages/adapter/src/steps/setup.ts
+++ b/packages/adapter/src/steps/setup.ts
@@ -5,6 +5,7 @@ import path from 'path'
 import type { Context } from '../types/Context.js'
 import { copy } from '../utils/copy.js'
 import { root } from '../utils/root.js'
+import { aws_lambda } from 'aws-cdk-lib'
 
 export const setup = async ({ builder, tmp, options }: Context) => {
   const {
@@ -71,7 +72,8 @@ export const setup = async ({ builder, tmp, options }: Context) => {
       __DOMAIN_NAME__: options.domain?.fqdn ?? '',
       __CERTIFICATE_ARN__: options.domain?.certificateArn ?? '',
       __LAMBDA_RUNTIME__: options.runtime ?? 'NODE_LATEST',
-      '{} /* $$__ENVIRONMENT__$$ */': JSON.stringify(options.env ?? {})
+      '{} /* $$__ENVIRONMENT__$$ */': JSON.stringify(options.env ?? {}),
+      '(lambdaFunction: aws_lambda.Function) => {} /* $$__LAMBDA_MODIFIER__$$ */': `${options.lambdaModifier ?? '(lambdaFunction: aws_lambda.Function) => {}'}`
     }
   )
 

--- a/packages/adapter/src/steps/setup.ts
+++ b/packages/adapter/src/steps/setup.ts
@@ -5,7 +5,6 @@ import path from 'path'
 import type { Context } from '../types/Context.js'
 import { copy } from '../utils/copy.js'
 import { root } from '../utils/root.js'
-import { aws_lambda } from 'aws-cdk-lib'
 
 export const setup = async ({ builder, tmp, options }: Context) => {
   const {
@@ -73,7 +72,15 @@ export const setup = async ({ builder, tmp, options }: Context) => {
       __CERTIFICATE_ARN__: options.domain?.certificateArn ?? '',
       __LAMBDA_RUNTIME__: options.runtime ?? 'NODE_LATEST',
       '{} /* $$__ENVIRONMENT__$$ */': JSON.stringify(options.env ?? {}),
-      '(lambdaFunction: aws_lambda.Function) => {} /* $$__LAMBDA_MODIFIER__$$ */': `${options.lambdaModifier ?? '(lambdaFunction: aws_lambda.Function) => {}'}`
+    }
+  )
+
+  await copy(
+    path.join(cdkPath, 'external', 'cdk-modifiers.ts'),
+    path.join(options.out, 'external', 'cdk-modifiers.ts'),
+    {
+      '/* $$__ADAPTER_IMPORTS__$$ */': options.adapterImports?.join('\n') ?? '',
+      '(lambdaFunction: cdk.aws_lambda.Function) => {} /* $$__LAMBDA_MODIFIER__$$ */': `${options.lambdaModifier ?? '(lambdaFunction: cdk.aws_lambda.Function) => {}'}`
     }
   )
 

--- a/packages/adapter/src/steps/setup.ts
+++ b/packages/adapter/src/steps/setup.ts
@@ -80,7 +80,7 @@ export const setup = async ({ builder, tmp, options }: Context) => {
     path.join(options.out, 'external', 'cdk-modifiers.ts'),
     {
       '/* $$__ADAPTER_IMPORTS__$$ */': options.adapterImports?.join('\n') ?? '',
-      '(lambdaFunction: cdk.aws_lambda.Function) => {} /* $$__LAMBDA_MODIFIER__$$ */': `${options.lambdaModifier ?? '(lambdaFunction: cdk.aws_lambda.Function) => {}'}`
+      '(lambdaFunction: cdk.aws_lambda.Function) => {} /* $$__LAMBDA_MODIFIER__$$ */': options.lambdaModifier?.toString() ?? '(lambdaFunction: cdk.aws_lambda.Function) => {}'
     }
   )
 

--- a/packages/adapter/src/types/AdapterOptions.ts
+++ b/packages/adapter/src/types/AdapterOptions.ts
@@ -90,6 +90,22 @@ export type AdapterOptions = {
      */
     certificateArn: string
   }
+  /**
+   * Adds imports to the adapter params.ts to allow things like `lambdaModifier` 
+   * to access types
+   * @example ["import { Stack } from 'aws-cdk-lib'"]
+   */
+  adapterImports?: string[]
 
+  /**
+   * Allows custom modifications to the Lambda function during CDK stack creation
+   * @param lambdaFunction The Lambda function to modify
+   * @example
+   * ```ts
+   * lambdaModifier: (fn) => {
+   *   fn.addEnvironment('CUSTOM_VAR', 'value');
+   * }
+   * ```
+   */
   lambdaModifier?: (lambdaFunction: aws_lambda.Function) => { }
 }

--- a/packages/adapter/src/types/AdapterOptions.ts
+++ b/packages/adapter/src/types/AdapterOptions.ts
@@ -1,5 +1,6 @@
 import { BuildOptions } from 'esbuild'
 import type { ArchitectureType } from './ArchitectureType.js'
+import { aws_lambda } from 'aws-cdk-lib'
 
 export type AdapterOptions = {
   /**
@@ -89,4 +90,6 @@ export type AdapterOptions = {
      */
     certificateArn: string
   }
+
+  lambdaModifier?: (lambdaFunction: aws_lambda.Function) => { }
 }

--- a/packages/site/svelte.config.js
+++ b/packages/site/svelte.config.js
@@ -1,5 +1,6 @@
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
 import adapter from '../../dist/index.js'
+import { Stack } from 'aws-cdk-lib'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -29,7 +30,12 @@ const config = {
         KEY2: 'VALUE2',
         KEY3: 'VALUE3'
       },
-      stream: process.env.BUFFERED_RESPONSE !== 'TRUE'
+      stream: process.env.BUFFERED_RESPONSE !== 'TRUE',
+      adapterImports: [ "import { Stack } from 'aws-cdk-lib'" ],
+      lambdaModifier: (fn) => {
+        const stack = Stack.of(fn)
+        fn.addEnvironment("abc", "def")
+      }
     })
   }
 }


### PR DESCRIPTION
This PR allows modifying the CDK lambda without messing about in the generated files at all. It simply adds a modifier to the adapter that gives the user access to the lambda function. 
I was able to test and it works in my AWS account, but I can't update the playright tests because I do not know what infra is available and don't want to go mucking about in the account like that. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `lambdaModifier` functionality for AWS Lambda, allowing custom modifications before adding function URLs.
	- Added `adapterImports` property to support custom imports in adapter parameters.
	- New `lambdaModifier` function defined in the configuration for environment variable management.

- **Bug Fixes**
	- Improved clarity by renaming variables and restructuring code for better readability.

- **Documentation**
	- Updated type definitions to include new optional properties in `AdapterOptions`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->