### PR TITLE
feat: add support for configuring S3 Transfer Acceleration

### DIFF
--- a/cdk/arch/edge-bundled.ts
+++ b/cdk/arch/edge-bundled.ts
@@ -16,7 +16,8 @@ import {
   certificateArn,
   domainName,
   lambdaRuntime,
-  memorySize
+  memorySize,
+  s3TransferAcceleration,
 } from '../external/params'
 
 export class CDKStack extends Stack {
@@ -43,7 +44,7 @@ export class CDKStack extends Stack {
     })
 
     const s3 = new aws_s3.Bucket(this, 'Bucket', {
-      transferAcceleration: true
+      transferAcceleration: s3TransferAcceleration,
     })
 
     const behaviorBase = {

--- a/cdk/arch/edge-unbundled.ts
+++ b/cdk/arch/edge-unbundled.ts
@@ -20,7 +20,8 @@ import {
   environment,
   lambdaRuntime,
   memorySize,
-  stream
+  stream,
+  s3TransferAcceleration,
 } from '../external/params'
 
 export class CDKStack extends Stack {
@@ -68,7 +69,7 @@ export class CDKStack extends Stack {
     })
 
     const s3 = new aws_s3.Bucket(this, 'Bucket', {
-      transferAcceleration: true
+      transferAcceleration: s3TransferAcceleration,
     })
 
     const lambdaOriginStr = Fn.select(2, Fn.split('/', lambdaURL.url))

--- a/cdk/arch/lambda-s3.ts
+++ b/cdk/arch/lambda-s3.ts
@@ -20,7 +20,8 @@ import {
   environment,
   lambdaRuntime,
   memorySize,
-  stream
+  stream,
+  s3TransferAcceleration,
 } from '../external/params'
 import { lambdaModifier } from '../external/cdk-modifiers'
 
@@ -41,7 +42,7 @@ export class CDKStack extends Stack {
       memorySize,
       timeout: Duration.seconds(30),
       environment
-    })
+    });
 
     // allow custom modification of CDK lambda function
     lambdaModifier(lambdaFunction)
@@ -62,7 +63,7 @@ export class CDKStack extends Stack {
       : undefined
 
     const s3 = new aws_s3.Bucket(this, 'Bucket', {
-      transferAcceleration: true
+      transferAcceleration: s3TransferAcceleration
     })
 
     const cf2 = new aws_cloudfront.Function(this, 'CF2', {

--- a/cdk/external/params.ts
+++ b/cdk/external/params.ts
@@ -6,6 +6,7 @@ export const appPath = `${base}/${appDir}/*`
 export const memorySize = 128 /* $$__MEMORY_SIZE__$$ */
 export const environment = {} /* $$__ENVIRONMENT__$$ */
 export const cdn = false /* $$__ENABLE_CDN__$$ */
+export const s3TransferAcceleration = false /* $$__ENABLE_S3_TRANSFER_ACCELERATION__$$ */
 export const stream = true /* $$__ENABLE_STREAM__$$ */
 export const bridgeAuthToken = '__BRIDGE_AUTH_TOKEN__'
 export const lambdaRuntime: 'NODE_LATEST' | 'NODE_20' | 'NODE_18' =

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "test": "pnpm build:all && npx playwright test --ui"
   },
   "peerDependencies": {
-    "@sveltejs/kit": "^2.0.0"
+    "@sveltejs/kit": "^2.0.0",
+    "awk-cdk-lib": "^2.0.0"
   },
   "devDependencies": {
     "@jill64/eslint-config-ts": "2.0.1",
@@ -66,7 +67,7 @@
     "@sveltejs/kit": "2.15.1",
     "@types/node": "22.10.2",
     "@playwright/test": "1.49.1",
-    "cf2-builder": "1.1.29",
+    "cf2-builder": "1.1.30",
     "typescript": "5.7.2"
   },
   "dependencies": {

--- a/packages/adapter/src/adapter.ts
+++ b/packages/adapter/src/adapter.ts
@@ -25,6 +25,7 @@ export const adapter = (options?: AdapterOptions): Adapter => {
           memory: options?.memory ?? 128,
           deploy: options?.deploy ?? false,
           cdn: options?.cdn ?? false,
+          s3TransferAcceleration: options?.s3TransferAcceleration ?? false,
           stream: options?.stream ?? true
         },
         tmp

--- a/packages/adapter/src/steps/setup.ts
+++ b/packages/adapter/src/steps/setup.ts
@@ -64,6 +64,7 @@ export const setup = async ({ builder, tmp, options }: Context) => {
     {
       '128 /* $$__MEMORY_SIZE__$$ */': options.memory.toString(),
       'false /* $$__ENABLE_CDN__$$ */': options.cdn.toString(),
+      'false /* $$__ENABLE_S3_TRANSFER_ACCELERATION__$$ */': options.s3TransferAcceleration.toString(),
       'true /* $$__ENABLE_STREAM__$$ */': options.stream.toString(),
       __APP_DIR__: appDir,
       __BASE_PATH__: base,

--- a/packages/adapter/src/types/AdapterOptions.ts
+++ b/packages/adapter/src/types/AdapterOptions.ts
@@ -48,6 +48,14 @@ export type AdapterOptions = {
   cdn?: boolean
 
   /**
+   * Enable S3 Transfer Acceleration for static asset uploads.
+   * This can improve upload speeds for static assets to S3 but may incur additional costs.
+   * Note: Not included in AWS free tier, may cause an error on deployment and additional charges will apply.
+   * @default false
+   */
+  s3TransferAcceleration?: boolean
+
+  /**
    * Environment variables to set in Lambda
    * @default undefined
    */

--- a/packages/adapter/src/types/Context.ts
+++ b/packages/adapter/src/types/Context.ts
@@ -5,10 +5,10 @@ export type Context = {
   readonly builder: Builder
   readonly tmp: string
   readonly options: AdapterOptions &
-    Required<
-      Pick<
-        AdapterOptions,
-        'name' | 'out' | 'memory' | 'architecture' | 'deploy' | 'cdn' | 'stream'
-      >
+  Required<
+    Pick<
+      AdapterOptions,
+      'name' | 'out' | 'memory' | 'architecture' | 'deploy' | 'cdn' | 's3TransferAcceleration' | 'stream'
     >
+  >
 }


### PR DESCRIPTION
AWS free tier does not include support for transfer acceleration, resulting in an error on deployment.

I added support for configuring it through the svelte.config file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a dynamic option for S3 bucket transfer acceleration, allowing users to enable or disable this feature through configuration. This provides greater control over upload performance and associated costs.

- **Chores**
  - Updated dependency versions and added a new peer dependency to enhance compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->