### PR TITLE
add bridgeAuthToken option to AdapterOptions to simplify CDK integration

### DIFF
--- a/packages/adapter/src/adapter.ts
+++ b/packages/adapter/src/adapter.ts
@@ -26,7 +26,8 @@ export const adapter = (options?: AdapterOptions): Adapter => {
           deploy: options?.deploy ?? false,
           cdn: options?.cdn ?? false,
           s3TransferAcceleration: options?.s3TransferAcceleration ?? false,
-          stream: options?.stream ?? true
+          stream: options?.stream ?? true,
+          bridgeAuthToken: options?.bridgeAuthToken
         },
         tmp
       }

--- a/packages/adapter/src/steps/setup.ts
+++ b/packages/adapter/src/steps/setup.ts
@@ -55,7 +55,7 @@ export const setup = async ({ builder, tmp, options }: Context) => {
     }
   )
 
-  const bridgeAuthToken = nanoid()
+  const bridgeAuthToken = options.bridgeAuthToken ?? nanoid()
 
   builder.mkdirp(path.join(options.out, 'external'))
   await copy(

--- a/packages/adapter/src/types/AdapterOptions.ts
+++ b/packages/adapter/src/types/AdapterOptions.ts
@@ -116,4 +116,14 @@ export type AdapterOptions = {
    * ```
    */
   lambdaModifier?: (lambdaFunction: aws_lambda.Function) => unknown
+
+  /**
+   * A shared secret used to authenticate requests from CloudFront to the deployed Lambda.
+   * This is intended to prevent unauthorized direct access to the function URL.
+   * If not provided, a random token will be generated at build time.
+   * The token must match the value set in the CloudFront request header.
+   *
+   * @default undefined
+   */
+  bridgeAuthToken?: string
 }


### PR DESCRIPTION
Previously, bridgeAuthToken was always generated at build time using nanoid(), which meant the token value was not known until the build completed. This made it difficult to coordinate with external CDK-managed resources such as CloudFront headers.

While the default CDK stack generated by this adapter is sufficient in most cases, some use cases may require customization of the infrastructure.

This PR adds support for explicitly providing a bridgeAuthToken via AdapterOptions. If not provided, a token will still be automatically generated as before.

By allowing the token to be injected ahead of time, this change enables more deterministic and flexible integration between CloudFront and the Lambda function.

---

I'm still learning npm, SvelteKit, and AWS, so please forgive me if this PR misses the mark. Thank you very much for taking the time to review it.